### PR TITLE
make sure the current version is always incremented

### DIFF
--- a/server.go
+++ b/server.go
@@ -197,6 +197,7 @@ func (s *server) createBucketContainer(newConfig *pb.ServiceConfig) {
 func (s *server) updateConfig(user string, updater func(*pb.ServiceConfig) error) error {
 	s.Lock()
 	clonedCfg := proto.Clone(s.cfgs).(*pb.ServiceConfig)
+	currentVersion := clonedCfg.Version
 	s.Unlock()
 
 	err := updater(clonedCfg)
@@ -209,7 +210,7 @@ func (s *server) updateConfig(user string, updater func(*pb.ServiceConfig) error
 
 	clonedCfg.User = user
 	clonedCfg.Date = time.Now().Unix()
-	clonedCfg.Version = clonedCfg.Version + 1
+	clonedCfg.Version = currentVersion + 1
 
 	r, e := config.Marshal(clonedCfg)
 
@@ -222,6 +223,8 @@ func (s *server) updateConfig(user string, updater func(*pb.ServiceConfig) error
 
 // Implements admin.Administrable
 func (s *server) Configs() *pb.ServiceConfig {
+	s.RLock()
+	defer s.RUnlock()
 	return s.cfgs
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -5,6 +5,7 @@ package quotaservice
 
 import (
 	"testing"
+	"time"
 
 	"github.com/maniksurtani/quotaservice/config"
 	"github.com/maniksurtani/quotaservice/test/helpers"
@@ -20,4 +21,46 @@ func TestValidServer(t *testing.T) {
 	s := New(&MockBucketFactory{}, &config.MemoryConfigPersister{}, &MockEndpoint{})
 	s.Start()
 	defer s.Stop()
+}
+
+func TestUpdateConfig(t *testing.T) {
+	s := New(&MockBucketFactory{}, config.NewMemoryConfigPersister(), &MockEndpoint{}).(*server)
+
+	originalConfig := config.NewDefaultServiceConfig()
+	originalConfig.Version = 2
+	originalConfig.Date = time.Now().Unix() - 10
+	s.createBucketContainer(originalConfig)
+
+	s.Start()
+	defer s.Stop()
+
+	newConfig := config.NewDefaultServiceConfig()
+
+	if err := s.UpdateConfig(newConfig, "test"); err != nil {
+		t.Fatal("Error when updating config", err)
+	}
+
+	start := time.Now()
+
+	for s.Configs() == originalConfig {
+		if time.Since(start) > time.Second {
+			t.Fatal("Timeout waiting for config to change!")
+		}
+
+		time.Sleep(time.Millisecond * 5)
+	}
+
+	cfg := s.Configs()
+
+	if cfg.User != "test" {
+		t.Errorf("User %+v does not match passed in user \"test\"", s.cfgs.User)
+	}
+
+	if cfg.Version != 3 {
+		t.Errorf("Version %+v does not match current version: 3", s.cfgs.Version)
+	}
+
+	if cfg.Date <= originalConfig.Date {
+		t.Errorf("Date %+v was not updated from %+v", s.cfgs.Date, originalConfig.Date)
+	}
 }


### PR DESCRIPTION
Otherwise it can be overwritten when hitting POST /api/namespace