### PR TITLE
speed up dynamic bucket addition

### DIFF
--- a/benchmark/bucket_benchmark_test.go
+++ b/benchmark/bucket_benchmark_test.go
@@ -1,0 +1,44 @@
+// Licensed under the Apache License, Version 2.0
+// Details: https://raw.githubusercontent.com/maniksurtani/quotaservice/master/LICENSE
+
+// Package buckets defines interfaces for abstractions of token buckets.
+package benchmark
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/maniksurtani/quotaservice"
+	"github.com/maniksurtani/quotaservice/config"
+
+	pbconfig "github.com/maniksurtani/quotaservice/protos/config"
+)
+
+var benchmarkCfg = func() *pbconfig.ServiceConfig {
+	c := config.NewDefaultServiceConfig()
+	c.GlobalDefaultBucket = config.NewDefaultBucketConfig(config.DefaultBucketName)
+
+	// Namespace "y"
+	ns := config.NewDefaultNamespaceConfig("y")
+	ns.DynamicBucketTemplate = config.NewDefaultBucketConfig(config.DefaultBucketName)
+	ns.MaxDynamicBuckets = 0
+	config.AddBucket(ns, config.NewDefaultBucketConfig("y"))
+	config.AddNamespace(c, ns)
+
+	return c
+}()
+
+var benchmarkContainer, _, _ = quotaservice.NewBucketContainerWithMocks(benchmarkCfg)
+
+func BenchmarkDynamicBucket(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bucket := fmt.Sprintf("new.%d", i)
+		_, _ = benchmarkContainer.FindBucket("y", bucket)
+	}
+}
+
+func BenchmarkFindBucket(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = benchmarkContainer.FindBucket("y", "y")
+	}
+}


### PR DESCRIPTION
Remove the need to iterate over every bucket on each new dynamic bucket.

Before (admittedly contrived since each bucket is new):

```
$ go test -bench .
testing: warning: no tests to run
BenchmarkDynamicBucket-4           10000            237119 ns/op
PASS
ok      github.com/maniksurtani/quotaservice/benchmark  2.385s
```

After:

```
$ go test -bench .
testing: warning: no tests to run
BenchmarkDynamicBucket-4          500000              3459 ns/op
BenchmarkFindBucket-4           30000000                58.5 ns/op
PASS
ok      github.com/maniksurtani/quotaservice/benchmark  4.495s
```