### PR TITLE
add a way to grab redis client from bucket factory

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -100,6 +100,9 @@ type BucketFactory interface {
 
 	// NewBucket creates a new bucket.
 	NewBucket(namespace, bucketName string, cfg *pbconfig.BucketConfig, dyn bool) Bucket
+
+	// Client is an accessor to the underlying network client, if there is one.
+	Client() interface{}
 }
 
 // NewBucketContainer creates a new bucket container.

--- a/buckets/memory/bucket.go
+++ b/buckets/memory/bucket.go
@@ -26,6 +26,10 @@ func (bf *bucketFactory) Init(cfg *pbconfig.ServiceConfig) {
 	bf.cfg = cfg
 }
 
+func (bf *bucketFactory) Client() interface{} {
+	return nil
+}
+
 func (bf *bucketFactory) NewBucket(namespace, bucketName string, cfg *pbconfig.BucketConfig, dyn bool) quotaservice.Bucket {
 	// fill rate is tokens-per-second.
 	bucket := &tokenBucket{

--- a/buckets/redis/bucket.go
+++ b/buckets/redis/bucket.go
@@ -15,8 +15,9 @@ import (
 	"github.com/maniksurtani/quotaservice"
 	"github.com/maniksurtani/quotaservice/logging"
 
-	pbconfig "github.com/maniksurtani/quotaservice/protos/config"
 	"sync"
+
+	pbconfig "github.com/maniksurtani/quotaservice/protos/config"
 )
 
 // Suffixes for Redis keys
@@ -88,6 +89,10 @@ func (bf *bucketFactory) reconnectToRedis(oldClient *redis.Client) {
 	if oldClient == bf.client {
 		bf.connectToRedisLocked()
 	}
+}
+
+func (bf *bucketFactory) Client() interface{} {
+	return bf.client
 }
 
 func (bf *bucketFactory) NewBucket(namespace, bucketName string, cfg *pbconfig.BucketConfig, dyn bool) quotaservice.Bucket {

--- a/test_mocks.go
+++ b/test_mocks.go
@@ -62,6 +62,7 @@ func (bf *MockBucketFactory) bucket(namespace, name string) *MockBucket {
 }
 
 func (bf *MockBucketFactory) Init(cfg *pbconfig.ServiceConfig) {}
+func (bf *MockBucketFactory) Client() interface{}              { return nil }
 func (bf *MockBucketFactory) NewBucket(namespace, bucketName string, cfg *pbconfig.BucketConfig, dyn bool) Bucket {
 	b := &MockBucket{
 		WaitTime:   0,


### PR DESCRIPTION
Couldn't really think of a better way, even though the `interface{}` return is kind of terrible.