### PR TITLE
Add jitter to config reloads

### DIFF
--- a/api.go
+++ b/api.go
@@ -27,19 +27,21 @@ func NewWithDefaultConfig(bucketFactory BucketFactory, rpcEndpoints ...RpcEndpoi
 	return New(bucketFactory,
 		config.NewMemoryConfig(config.NewDefaultServiceConfig()),
 		config.NewReaperConfig(),
+		0,
 		rpcEndpoints...)
 }
 
 // New creates a new quotaservice server.
-func New(bucketFactory BucketFactory, persister config.ConfigPersister, reaperConfig config.ReaperConfig, rpcEndpoints ...RpcEndpoint) Server {
+func New(bucketFactory BucketFactory, persister config.ConfigPersister, reaperConfig config.ReaperConfig, maxCfgReloadJitterMs int, rpcEndpoints ...RpcEndpoint) Server {
 	if len(rpcEndpoints) == 0 {
 		panic("Need at least 1 RPC endpoint to run the quota service.")
 	}
 
 	s := &server{
-		persister:     persister,
-		bucketFactory: bucketFactory,
-		rpcEndpoints:  rpcEndpoints,
-		reaperConfig:  reaperConfig}
+		persister:       persister,
+		bucketFactory:   bucketFactory,
+		rpcEndpoints:    rpcEndpoints,
+		maxJitterMillis: maxCfgReloadJitterMs,
+		reaperConfig:    reaperConfig}
 	return s
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -41,6 +41,7 @@ func setUp() {
 	server = quotaservice.New(memory.NewBucketFactory(),
 		config.NewMemoryConfig(cfg),
 		quotaservice.NewReaperConfigForTests(),
+		0,
 		qsgrpc.New(target))
 
 	if _, err := server.Start(); err != nil {

--- a/events_test.go
+++ b/events_test.go
@@ -56,7 +56,7 @@ func setUp() {
 	mbf = &MockBucketFactory{}
 	me := &MockEndpoint{}
 	p := config.NewMemoryConfig(cfg)
-	s = New(mbf, p, NewReaperConfigForTests(), me)
+	s = New(mbf, p, NewReaperConfigForTests(), 0, me)
 	ecLocal := make(chan events.Event, 100)
 	s.SetListener(func(e events.Event) {
 		ecLocal <- e

--- a/server_test.go
+++ b/server_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestWithNoRpcs(t *testing.T) {
 	helpers.ExpectingPanic(t, func() {
-		New(&MockBucketFactory{}, &config.MemoryConfigPersister{}, NewReaperConfigForTests())
+		New(&MockBucketFactory{}, &config.MemoryConfigPersister{}, NewReaperConfigForTests(), 0)
 	})
 }
 
 func TestValidServer(t *testing.T) {
-	s := New(&MockBucketFactory{}, config.NewMemoryConfigPersister(), NewReaperConfigForTests(), &MockEndpoint{}).(*server)
+	s := New(&MockBucketFactory{}, config.NewMemoryConfigPersister(), NewReaperConfigForTests(), 0, &MockEndpoint{}).(*server)
 	_, err := s.Start()
 	helpers.CheckError(t, err)
 	stopServer(t, s)
@@ -26,7 +26,7 @@ func TestValidServer(t *testing.T) {
 
 func TestUpdateConfig(t *testing.T) {
 	p := config.NewMemoryConfigPersister()
-	s := New(&MockBucketFactory{}, p, NewReaperConfigForTests(), &MockEndpoint{}).(*server)
+	s := New(&MockBucketFactory{}, p, NewReaperConfigForTests(), 0, &MockEndpoint{}).(*server)
 
 	originalConfig := config.NewDefaultServiceConfig()
 	originalConfig.Version = 2
@@ -82,7 +82,7 @@ func TestTooManyTokensRequested(t *testing.T) {
 	helpers.CheckError(t, config.AddBucket(nsc, bc))
 	helpers.CheckError(t, config.AddNamespace(cfg, nsc))
 
-	s := New(&MockBucketFactory{}, config.NewMemoryConfig(cfg), NewReaperConfigForTests(), &MockEndpoint{}).(*server)
+	s := New(&MockBucketFactory{}, config.NewMemoryConfig(cfg), NewReaperConfigForTests(), 0, &MockEndpoint{}).(*server)
 	_, err := s.Start()
 	helpers.CheckError(t, err)
 	defer stopServer(t, s)

--- a/test/main.go
+++ b/test/main.go
@@ -43,6 +43,7 @@ func main() {
 	server := quotaservice.New(memory.NewBucketFactory(),
 		config.NewMemoryConfig(cfg),
 		config.NewReaperConfig(),
+		0,
 		grpc.New(gRPCServer))
 	server.SetStatsListener(stats.NewMemoryStatsListener())
 	if _, e := server.Start(); e != nil {


### PR DESCRIPTION
Might be useful to not have every node in a cluster reload configs at the same time - WDYT?